### PR TITLE
package malkusch/php-mock moved to php-mock/php-mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",
-        "malkusch/php-mock": "0.4.*",
+        "php-mock/php-mock-phpunit": "^0.2",
         "kherge/box": "~2.5",
         "sami/sami": "~2.0"
     }

--- a/tests/AppShed/Remote/HTML/RemoteTest.php
+++ b/tests/AppShed/Remote/HTML/RemoteTest.php
@@ -11,7 +11,7 @@ namespace AppShed\Remote\HTML;
 use AppShed\Remote\Element\Item\Marker;
 use AppShed\Remote\Element\Screen\Map;
 use AppShed\Remote\Element\Screen\Screen;
-use malkusch\phpmock\phpunit\PHPMock;
+use phpmock\phpunit\PHPMock;
 
 class RemoteTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Hi,
I moved malkusch/php-mock to [php-mock/php-mock](https://github.com/php-mock/php-mock).
